### PR TITLE
Reduce delta_rs_bridge size to 89MB

### DIFF
--- a/src/DeltaLake/Bridge/Cargo.toml
+++ b/src/DeltaLake/Bridge/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib", "rlib"]
 
 [profile.release]
 strip = true
-opt-level = 2
 lto = true
 codegen-units = 1
 


### PR DESCRIPTION
A middle ground between performance, size and build time:

- `strip = true` strips debug symbols (didn't see much difference from this though)
- `lto = true` enables LLVM's link-time optimisations
- `codegen-units = 1` forces compilation onto a single thread
  - Surprisingly this is the biggest win, shaving ~40MB off the binary size (at the cost of slower builds)

Can go as low as ~72MB by setting `opt-level = "z"` (or just `"s"`), which is equivalent to `-O2` + storage optimisations, but I think 89MB is fine to get `-O3` optimisations, though ofc in an ideal world you'd profile to see if this even makes a difference.

Still smaller than the current binaries I pulled from NuGet, which are 119MB