### PR TITLE
Enable CFG (Control Flow Guard) on Windows builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os = "windows")']
+rustflags = ["-C", "control-flow-guard=checks"]


### PR DESCRIPTION
Enable [CFG](https://en.wikipedia.org/wiki/Control-flow_integrity) on windows builds

Quick summary of CFG:
CFG is a Windows only feature (max / linux have alternatives under different names) that prevents attackers from hijacking control flow.

There is a slight performance cost to this feature but it shouldn't be too much