### PR TITLE
TransactionIdentifier Support for Blind Appends

### DIFF
--- a/src/DeltaLake/Interfaces/ITable.cs
+++ b/src/DeltaLake/Interfaces/ITable.cs
@@ -271,6 +271,20 @@ namespace DeltaLake.Interfaces
             IReadOnlyList<AddAction> actions,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Commits add-file actions to the Delta log without writing data files,
+        /// with options for transaction identifiers (idempotent writes).
+        /// Returns the new table version after commit.
+        /// </summary>
+        /// <param name="actions">File metadata for pre-written Parquet files to register.</param>
+        /// <param name="options">Options including optional transaction identifiers.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
+        /// <returns>A <see cref="Task{T}"/> representing the committed table version.</returns>
+        Task<long> CreateWriteTransactionAsync(
+            IReadOnlyList<AddAction> actions,
+            CommitOptions options,
+            CancellationToken cancellationToken);
+
         #endregion Transaction Log Operations
     }
 }

--- a/src/DeltaLake/Interfaces/ITable.cs
+++ b/src/DeltaLake/Interfaces/ITable.cs
@@ -285,6 +285,16 @@ namespace DeltaLake.Interfaces
             CommitOptions options,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Retrieves the current transaction version for a given application ID.
+        /// Returns null if no transaction has been recorded for this appId.
+        /// Used for idempotent write pre-checks.
+        /// </summary>
+        /// <param name="appId">The application identifier to look up.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
+        /// <returns>The last committed version for this appId, or null if none exists.</returns>
+        Task<long?> GetTransactionVersionAsync(string appId, CancellationToken cancellationToken);
+
         #endregion Transaction Log Operations
     }
 }

--- a/src/DeltaLake/Interfaces/ITable.cs
+++ b/src/DeltaLake/Interfaces/ITable.cs
@@ -276,6 +276,17 @@ namespace DeltaLake.Interfaces
         /// with options for transaction identifiers (idempotent writes).
         /// Returns the new table version after commit.
         /// </summary>
+        /// <remarks>
+        /// When <see cref="CommitOptions.AppId"/> and <see cref="CommitOptions.TransactionVersion"/>
+        /// are provided, a <c>txn</c> action is included in the commit alongside the <c>add</c> actions.
+        /// This records a progress marker for the application but does <b>not</b> enforce uniqueness —
+        /// duplicate appId/version pairs are accepted by the Delta kernel. During action reconciliation,
+        /// the latest <c>txn</c> version for a given appId wins.
+        /// <para>
+        /// To achieve idempotent writes, callers must check <see cref="GetLatestTransactionVersionAsync"/>
+        /// before committing and skip if the returned version is greater than or equal to the batch version.
+        /// </para>
+        /// </remarks>
         /// <param name="actions">File metadata for pre-written Parquet files to register.</param>
         /// <param name="options">Options including optional transaction identifiers.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
@@ -293,7 +304,7 @@ namespace DeltaLake.Interfaces
         /// <param name="appId">The application identifier to look up.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
         /// <returns>The last committed version for this appId, or null if none exists.</returns>
-        Task<long?> GetTransactionVersionAsync(string appId, CancellationToken cancellationToken);
+        Task<long?> GetLatestTransactionVersionAsync(string appId, CancellationToken cancellationToken);
 
         #endregion Transaction Log Operations
     }

--- a/src/DeltaLake/Kernel/Core/Table.cs
+++ b/src/DeltaLake/Kernel/Core/Table.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using DeltaLake.Bridge.Interop;
 using DeltaLake.Extensions;
@@ -346,6 +347,62 @@ namespace DeltaLake.Kernel.Core
                                 this.addFilesNativeSchema,
                                 appId,
                                 txnVersion);
+                        }
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves the current transaction version for a given application ID.
+        /// Returns null if no transaction has been recorded for this appId.
+        /// </summary>
+        /// <param name="appId">The application identifier to look up.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The last committed version for this appId, or null if none exists.</returns>
+        internal async Task<long?> GetTransactionVersionAsync(
+            string appId,
+            ICancellationToken cancellationToken)
+        {
+            this.ThrowIfKernelNotSupported();
+
+            return await SyncToAsyncShim
+                .ExecuteAsync(
+                    () =>
+                    {
+                        unsafe
+                        {
+                            byte[] appIdBytes = Encoding.UTF8.GetBytes(appId);
+                            fixed (byte* appIdPtr = appIdBytes)
+                            {
+                                var appIdSlice = new KernelStringSlice
+                                {
+                                    ptr = appIdPtr,
+                                    len = (nuint)appIdBytes.Length,
+                                };
+
+                                SharedSnapshot* snapshotPtr = this.state.Snapshot(true);
+
+                                ExternResultOptionalValuei64 result =
+                                    Methods.get_app_id_version(
+                                        snapshotPtr, appIdSlice, this.kernelOwnedSharedExternEnginePtr);
+
+                                if (result.tag != ExternResultOptionalValuei64_Tag.OkOptionalValuei64)
+                                {
+                                    throw KernelException.FromEngineError(
+                                        result.Anonymous.Anonymous2_1.err,
+                                        "Failed to get transaction version");
+                                }
+
+                                OptionalValuei64 optVal = result.Anonymous.Anonymous1_1.ok;
+                                if (optVal.tag == OptionalValuei64_Tag.Somei64)
+                                {
+                                    return (long?)optVal.some;
+                                }
+
+                                return (long?)null;
+                            }
                         }
                     },
                     cancellationToken

--- a/src/DeltaLake/Kernel/Core/Table.cs
+++ b/src/DeltaLake/Kernel/Core/Table.cs
@@ -319,10 +319,14 @@ namespace DeltaLake.Kernel.Core
         /// Returns the new table version after commit.
         /// </summary>
         /// <param name="actions">File metadata for pre-written Parquet files.</param>
+        /// <param name="appId">Optional application identifier for idempotent writes.</param>
+        /// <param name="txnVersion">Optional application-specific version for idempotent writes.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The committed table version number.</returns>
         internal async Task<ulong> CommitAddActionsAsync(
             IReadOnlyList<AddAction> actions,
+            string? appId,
+            long? txnVersion,
             ICancellationToken cancellationToken)
         {
             this.ThrowIfKernelNotSupported();
@@ -339,7 +343,9 @@ namespace DeltaLake.Kernel.Core
                                 this.tableLocationSlice,
                                 this.kernelOwnedSharedExternEnginePtr,
                                 addFilesBatch,
-                                this.addFilesNativeSchema);
+                                this.addFilesNativeSchema,
+                                appId,
+                                txnVersion);
                         }
                     },
                     cancellationToken

--- a/src/DeltaLake/Kernel/Core/Table.cs
+++ b/src/DeltaLake/Kernel/Core/Table.cs
@@ -13,7 +13,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using DeltaLake.Bridge.Interop;
 using DeltaLake.Extensions;
@@ -361,7 +360,7 @@ namespace DeltaLake.Kernel.Core
         /// <param name="appId">The application identifier to look up.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The last committed version for this appId, or null if none exists.</returns>
-        internal async Task<long?> GetTransactionVersionAsync(
+        internal async Task<long?> GetLatestTransactionVersionAsync(
             string appId,
             ICancellationToken cancellationToken)
         {
@@ -373,36 +372,10 @@ namespace DeltaLake.Kernel.Core
                     {
                         unsafe
                         {
-                            byte[] appIdBytes = Encoding.UTF8.GetBytes(appId);
-                            fixed (byte* appIdPtr = appIdBytes)
-                            {
-                                var appIdSlice = new KernelStringSlice
-                                {
-                                    ptr = appIdPtr,
-                                    len = (nuint)appIdBytes.Length,
-                                };
-
-                                SharedSnapshot* snapshotPtr = this.state.Snapshot(true);
-
-                                ExternResultOptionalValuei64 result =
-                                    Methods.get_app_id_version(
-                                        snapshotPtr, appIdSlice, this.kernelOwnedSharedExternEnginePtr);
-
-                                if (result.tag != ExternResultOptionalValuei64_Tag.OkOptionalValuei64)
-                                {
-                                    throw KernelException.FromEngineError(
-                                        result.Anonymous.Anonymous2_1.err,
-                                        "Failed to get transaction version");
-                                }
-
-                                OptionalValuei64 optVal = result.Anonymous.Anonymous1_1.ok;
-                                if (optVal.tag == OptionalValuei64_Tag.Somei64)
-                                {
-                                    return (long?)optVal.some;
-                                }
-
-                                return (long?)null;
-                            }
+                            return TransactionCommitter.GetLatestTransactionVersion(
+                                this.state.Snapshot(true),
+                                appId,
+                                this.kernelOwnedSharedExternEnginePtr);
                         }
                     },
                     cancellationToken

--- a/src/DeltaLake/Kernel/Interop/Interop.cs
+++ b/src/DeltaLake/Kernel/Interop/Interop.cs
@@ -1415,6 +1415,56 @@ namespace DeltaLake.Kernel.Interop
         }
     }
 
+    [NativeTypeName("unsigned int")]
+    internal enum OptionalValuei64_Tag : uint
+    {
+        Somei64,
+        Nonei64,
+    }
+
+    internal partial struct OptionalValuei64
+    {
+        public OptionalValuei64_Tag tag;
+
+        [NativeTypeName("int64_t")]
+        public long some;
+    }
+
+    [NativeTypeName("unsigned int")]
+    internal enum ExternResultOptionalValuei64_Tag : uint
+    {
+        OkOptionalValuei64,
+        ErrOptionalValuei64,
+    }
+
+    internal unsafe partial struct ExternResultOptionalValuei64
+    {
+        public ExternResultOptionalValuei64_Tag tag;
+
+        public _Anonymous_e__Union Anonymous;
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal unsafe partial struct _Anonymous_e__Union
+        {
+            [FieldOffset(0)]
+            public _Anonymous1_1_e__Struct Anonymous1_1;
+
+            [FieldOffset(0)]
+            public _Anonymous2_1_e__Struct Anonymous2_1;
+
+            internal partial struct _Anonymous1_1_e__Struct
+            {
+                public OptionalValuei64 ok;
+            }
+
+            internal unsafe partial struct _Anonymous2_1_e__Struct
+            {
+                [NativeTypeName("struct EngineError *")]
+                public EngineError* err;
+            }
+        }
+    }
+
     internal static unsafe partial class Methods
     {
         [DllImport("delta_kernel_ffi", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/src/DeltaLake/Kernel/Interop/Interop.cs
+++ b/src/DeltaLake/Kernel/Interop/Interop.cs
@@ -1415,56 +1415,6 @@ namespace DeltaLake.Kernel.Interop
         }
     }
 
-    [NativeTypeName("unsigned int")]
-    internal enum OptionalValuei64_Tag : uint
-    {
-        Somei64,
-        Nonei64,
-    }
-
-    internal partial struct OptionalValuei64
-    {
-        public OptionalValuei64_Tag tag;
-
-        [NativeTypeName("int64_t")]
-        public long some;
-    }
-
-    [NativeTypeName("unsigned int")]
-    internal enum ExternResultOptionalValuei64_Tag : uint
-    {
-        OkOptionalValuei64,
-        ErrOptionalValuei64,
-    }
-
-    internal unsafe partial struct ExternResultOptionalValuei64
-    {
-        public ExternResultOptionalValuei64_Tag tag;
-
-        public _Anonymous_e__Union Anonymous;
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe partial struct _Anonymous_e__Union
-        {
-            [FieldOffset(0)]
-            public _Anonymous1_1_e__Struct Anonymous1_1;
-
-            [FieldOffset(0)]
-            public _Anonymous2_1_e__Struct Anonymous2_1;
-
-            internal partial struct _Anonymous1_1_e__Struct
-            {
-                public OptionalValuei64 ok;
-            }
-
-            internal unsafe partial struct _Anonymous2_1_e__Struct
-            {
-                [NativeTypeName("struct EngineError *")]
-                public EngineError* err;
-            }
-        }
-    }
-
     internal static unsafe partial class Methods
     {
         [DllImport("delta_kernel_ffi", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/src/DeltaLake/Kernel/Transaction/TransactionCommitter.cs
+++ b/src/DeltaLake/Kernel/Transaction/TransactionCommitter.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using Apache.Arrow;
 using Apache.Arrow.C;
 using DeltaLake.Kernel.Callbacks.Errors;
@@ -36,12 +37,16 @@ namespace DeltaLake.Kernel.Transaction
         /// <param name="enginePtr">The shared extern engine pointer.</param>
         /// <param name="addFilesBatch">The RecordBatch containing add-file metadata.</param>
         /// <param name="addFilesSchema">Pre-exported CArrowSchema pointer (reused across commits).</param>
+        /// <param name="appId">Optional application identifier for idempotent writes (Delta Protocol txn action).</param>
+        /// <param name="txnVersion">Optional application-specific version for idempotent writes (Delta Protocol txn action).</param>
         /// <returns>The committed table version number.</returns>
         internal static unsafe ulong Commit(
             KernelStringSlice tableLocationSlice,
             SharedExternEngine* enginePtr,
             RecordBatch addFilesBatch,
-            CArrowSchema* addFilesSchema)
+            CArrowSchema* addFilesSchema,
+            string? appId = null,
+            long? txnVersion = null)
         {
             ExternResultHandleExclusiveTransaction txnResult =
                 Methods.transaction(tableLocationSlice, enginePtr);
@@ -59,6 +64,31 @@ namespace DeltaLake.Kernel.Transaction
             try
             {
                 Methods.set_data_change(txnPtr, true);
+
+                if (appId != null && txnVersion.HasValue)
+                {
+                    byte[] appIdBytes = Encoding.UTF8.GetBytes(appId);
+                    fixed (byte* appIdPtr = appIdBytes)
+                    {
+                        var appIdSlice = new KernelStringSlice
+                        {
+                            ptr = appIdPtr,
+                            len = (nuint)appIdBytes.Length,
+                        };
+
+                        ExternResultHandleExclusiveTransaction txnIdResult =
+                            Methods.with_transaction_id(txnPtr, appIdSlice, txnVersion.Value, enginePtr);
+
+                        if (txnIdResult.tag != ExternResultHandleExclusiveTransaction_Tag.OkHandleExclusiveTransaction)
+                        {
+                            throw KernelException.FromEngineError(
+                                txnIdResult.Anonymous.Anonymous2_1.err,
+                                "Failed to set transaction identifier");
+                        }
+
+                        txnPtr = txnIdResult.Anonymous.Anonymous1_1.ok;
+                    }
+                }
 
                 var errorAllocatorHandle = GCHandle.Alloc(
                     (AllocateErrorFn)AllocateErrorCallbacks.AllocateError);

--- a/src/DeltaLake/Kernel/Transaction/TransactionCommitter.cs
+++ b/src/DeltaLake/Kernel/Transaction/TransactionCommitter.cs
@@ -65,7 +65,7 @@ namespace DeltaLake.Kernel.Transaction
             {
                 Methods.set_data_change(txnPtr, true);
 
-                if (appId != null && txnVersion.HasValue)
+                if (appId != null)
                 {
                     byte[] appIdBytes = Encoding.UTF8.GetBytes(appId);
                     fixed (byte* appIdPtr = appIdBytes)
@@ -149,6 +149,43 @@ namespace DeltaLake.Kernel.Transaction
                 {
                     Methods.free_transaction(txnPtr);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Queries the latest transaction version for a given application ID from a snapshot.
+        /// Returns null if no transaction has been recorded for this appId.
+        /// </summary>
+        /// <param name="snapshotPtr">The shared snapshot pointer.</param>
+        /// <param name="appId">The application identifier to look up.</param>
+        /// <param name="enginePtr">The shared extern engine pointer.</param>
+        /// <returns>The last committed version for this appId, or null if none exists.</returns>
+        internal static unsafe long? GetLatestTransactionVersion(
+            SharedSnapshot* snapshotPtr,
+            string appId,
+            SharedExternEngine* enginePtr)
+        {
+            byte[] appIdBytes = Encoding.UTF8.GetBytes(appId);
+            fixed (byte* appIdPtr = appIdBytes)
+            {
+                var appIdSlice = new KernelStringSlice
+                {
+                    ptr = appIdPtr,
+                    len = (nuint)appIdBytes.Length,
+                };
+
+                ExternResultOptionalValuei64 result =
+                    Methods.get_app_id_version(snapshotPtr, appIdSlice, enginePtr);
+
+                if (result.tag != ExternResultOptionalValuei64_Tag.OkOptionalValuei64)
+                {
+                    throw KernelException.FromEngineError(
+                        result.Anonymous.Anonymous2_1.err,
+                        "Failed to get transaction version");
+                }
+
+                OptionalValuei64 optVal = result.Anonymous.Anonymous1_1.ok;
+                return optVal.tag == OptionalValuei64_Tag.Somei64 ? optVal.Anonymous.Anonymous_1.some : null;
             }
         }
     }

--- a/src/DeltaLake/Table/CommitOptions.cs
+++ b/src/DeltaLake/Table/CommitOptions.cs
@@ -11,5 +11,18 @@ namespace DeltaLake.Table
         /// Optional custom metadata to include in the commit.
         /// </summary>
         public Dictionary<string, string>? CustomMetadata { get; init; }
+
+        /// <summary>
+        /// Application identifier for idempotent writes (Delta Protocol txn action).
+        /// When set along with <see cref="TransactionVersion"/>, a SetTransaction action
+        /// is included in the commit for exactly-once semantics.
+        /// </summary>
+        public string? AppId { get; init; }
+
+        /// <summary>
+        /// Application-specific version for idempotent writes (Delta Protocol txn action).
+        /// Must be set together with <see cref="AppId"/>.
+        /// </summary>
+        public long? TransactionVersion { get; init; }
     }
 }

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -263,6 +263,15 @@ namespace DeltaLake.Table
             return (long)version;
         }
 
+        /// <inheritdoc/>
+        public async Task<long?> GetTransactionVersionAsync(
+            string appId,
+            CancellationToken cancellationToken)
+        {
+            return await this.table.GetTransactionVersionAsync(appId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         #endregion ITable implementation
 
         #region IDisposable implementation

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -245,7 +245,9 @@ namespace DeltaLake.Table
                     new ArgumentException("actions cannot be null or empty", nameof(actions)));
             }
 
-            if (options?.AppId != null ^ options?.TransactionVersion.HasValue == true)
+            bool hasAppId = options?.AppId != null;
+            bool hasVersion = options?.TransactionVersion.HasValue == true;
+            if (hasAppId != hasVersion)
             {
                 throw new DeltaConfigurationException(
                     "Both AppId and TransactionVersion must be provided together, or both must be omitted.",

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -225,20 +225,11 @@ namespace DeltaLake.Table
         }
 
         /// <inheritdoc/>
-        public async Task<long> CreateWriteTransactionAsync(
+        public Task<long> CreateWriteTransactionAsync(
             IReadOnlyList<AddAction> actions,
             CancellationToken cancellationToken)
         {
-            if (actions == null || actions.Count == 0)
-            {
-                throw new DeltaConfigurationException(
-                    "At least one action is required",
-                    new ArgumentException("actions cannot be null or empty", nameof(actions)));
-            }
-
-            var version = await this.table.CommitAddActionsAsync(actions, null, null, cancellationToken)
-                .ConfigureAwait(false);
-            return (long)version;
+            return this.CreateWriteTransactionAsync(actions, new CommitOptions(), cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -254,6 +245,13 @@ namespace DeltaLake.Table
                     new ArgumentException("actions cannot be null or empty", nameof(actions)));
             }
 
+            if (options?.AppId != null ^ options?.TransactionVersion.HasValue == true)
+            {
+                throw new DeltaConfigurationException(
+                    "Both AppId and TransactionVersion must be provided together, or both must be omitted.",
+                    new ArgumentException("AppId and TransactionVersion must be set together", nameof(options)));
+            }
+
             var version = await this.table.CommitAddActionsAsync(
                 actions,
                 options?.AppId,
@@ -264,13 +262,10 @@ namespace DeltaLake.Table
         }
 
         /// <inheritdoc/>
-        public async Task<long?> GetTransactionVersionAsync(
+        public Task<long?> GetLatestTransactionVersionAsync(
             string appId,
-            CancellationToken cancellationToken)
-        {
-            return await this.table.GetTransactionVersionAsync(appId, cancellationToken)
-                .ConfigureAwait(false);
-        }
+            CancellationToken cancellationToken) =>
+            this.table.GetLatestTransactionVersionAsync(appId, cancellationToken);
 
         #endregion ITable implementation
 

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -228,9 +228,7 @@ namespace DeltaLake.Table
         public Task<long> CreateWriteTransactionAsync(
             IReadOnlyList<AddAction> actions,
             CancellationToken cancellationToken)
-        {
-            return this.CreateWriteTransactionAsync(actions, new CommitOptions(), cancellationToken);
-        }
+            => this.CreateWriteTransactionAsync(actions, new CommitOptions(), cancellationToken);
 
         /// <inheritdoc/>
         public async Task<long> CreateWriteTransactionAsync(
@@ -246,7 +244,7 @@ namespace DeltaLake.Table
             }
 
             bool hasAppId = options?.AppId != null;
-            bool hasVersion = options?.TransactionVersion.HasValue == true;
+            bool hasVersion = options?.TransactionVersion != null;
             if (hasAppId != hasVersion)
             {
                 throw new DeltaConfigurationException(
@@ -266,8 +264,8 @@ namespace DeltaLake.Table
         /// <inheritdoc/>
         public Task<long?> GetLatestTransactionVersionAsync(
             string appId,
-            CancellationToken cancellationToken) =>
-            this.table.GetLatestTransactionVersionAsync(appId, cancellationToken);
+            CancellationToken cancellationToken)
+            => this.table.GetLatestTransactionVersionAsync(appId, cancellationToken);
 
         #endregion ITable implementation
 

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -236,7 +236,29 @@ namespace DeltaLake.Table
                     new ArgumentException("actions cannot be null or empty", nameof(actions)));
             }
 
-            var version = await this.table.CommitAddActionsAsync(actions, cancellationToken)
+            var version = await this.table.CommitAddActionsAsync(actions, null, null, cancellationToken)
+                .ConfigureAwait(false);
+            return (long)version;
+        }
+
+        /// <inheritdoc/>
+        public async Task<long> CreateWriteTransactionAsync(
+            IReadOnlyList<AddAction> actions,
+            CommitOptions options,
+            CancellationToken cancellationToken)
+        {
+            if (actions == null || actions.Count == 0)
+            {
+                throw new DeltaConfigurationException(
+                    "At least one action is required",
+                    new ArgumentException("actions cannot be null or empty", nameof(actions)));
+            }
+
+            var version = await this.table.CommitAddActionsAsync(
+                actions,
+                options?.AppId,
+                options?.TransactionVersion,
+                cancellationToken)
                 .ConfigureAwait(false);
             return (long)version;
         }

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -428,4 +428,163 @@ public class CreateWriteTransactionTests
             info.Delete(true);
         }
     }
+
+    [Fact]
+    public async Task CreateWriteTransaction_With_TransactionId_Succeeds()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var actions = new List<AddAction>
+            {
+                new AddAction
+                {
+                    Path = "part-00000.parquet",
+                    Size = 1024,
+                    ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    DataChange = true,
+                },
+            };
+
+            var options = new CommitOptions
+            {
+                AppId = "test-app-id-12345",
+                TransactionVersion = 42,
+            };
+
+            var newVersion = await table.CreateWriteTransactionAsync(
+                actions,
+                options,
+                CancellationToken.None);
+
+            Assert.True(newVersion > 0);
+
+            // Verify the txn action is in the Delta log
+            var logDir = Path.Combine(info.FullName, "_delta_log");
+            var logFile = Path.Combine(logDir, $"{newVersion:D20}.json");
+            var logContent = await File.ReadAllTextAsync(logFile);
+
+            Assert.Contains("\"txn\"", logContent);
+            Assert.Contains("test-app-id-12345", logContent);
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task CreateWriteTransaction_With_Options_No_TransactionId_Succeeds()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var actions = new List<AddAction>
+            {
+                new AddAction
+                {
+                    Path = "part-00000.parquet",
+                    Size = 1024,
+                    ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    DataChange = true,
+                },
+            };
+
+            var options = new CommitOptions();
+
+            var newVersion = await table.CreateWriteTransactionAsync(
+                actions,
+                options,
+                CancellationToken.None);
+
+            Assert.True(newVersion > 0);
+
+            // Verify no txn action in the log
+            var logDir = Path.Combine(info.FullName, "_delta_log");
+            var logFile = Path.Combine(logDir, $"{newVersion:D20}.json");
+            var logContent = await File.ReadAllTextAsync(logFile);
+
+            Assert.DoesNotContain("\"txn\"", logContent);
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task CreateWriteTransaction_With_Options_Empty_Actions_Throws()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var options = new CommitOptions
+            {
+                AppId = "test-app",
+                TransactionVersion = 1,
+            };
+
+            await Assert.ThrowsAsync<DeltaConfigurationException>(
+                () => table.CreateWriteTransactionAsync(
+                    new List<AddAction>(),
+                    options,
+                    CancellationToken.None));
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task CreateWriteTransaction_Multiple_Commits_With_TransactionId_Increment()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var baseVersion = (long)table.Version()!;
+
+            for (int i = 1; i <= 3; i++)
+            {
+                var actions = new List<AddAction>
+                {
+                    new AddAction
+                    {
+                        Path = $"part-{i:D5}.parquet",
+                        Size = 1024 * i,
+                        ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    },
+                };
+
+                var options = new CommitOptions
+                {
+                    AppId = "streaming-app",
+                    TransactionVersion = i,
+                };
+
+                var newVersion = await table.CreateWriteTransactionAsync(
+                    actions,
+                    options,
+                    CancellationToken.None);
+
+                Assert.Equal(baseVersion + i, newVersion);
+            }
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
 }

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -652,7 +652,7 @@ public class CreateWriteTransactionTests
     }
 
     [Fact]
-    public async Task GetTransactionVersion_Returns_Version_After_Commit()
+    public async Task GetLatestTransactionVersion_Returns_Version_After_Commit()
     {
         var info = DirectoryHelpers.CreateTempSubdirectory();
         try
@@ -682,7 +682,7 @@ public class CreateWriteTransactionTests
                 options,
                 CancellationToken.None);
 
-            var txnVersion = await table.GetTransactionVersionAsync(
+            var txnVersion = await table.GetLatestTransactionVersionAsync(
                 "version-query-app",
                 CancellationToken.None);
 
@@ -695,7 +695,7 @@ public class CreateWriteTransactionTests
     }
 
     [Fact]
-    public async Task GetTransactionVersion_Returns_Null_For_Unknown_AppId()
+    public async Task GetLatestTransactionVersion_Returns_Null_For_Unknown_AppId()
     {
         var info = DirectoryHelpers.CreateTempSubdirectory();
         try
@@ -703,7 +703,7 @@ public class CreateWriteTransactionTests
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
             using var table = tableParts.table;
 
-            var txnVersion = await table.GetTransactionVersionAsync(
+            var txnVersion = await table.GetLatestTransactionVersionAsync(
                 "nonexistent-app",
                 CancellationToken.None);
 
@@ -716,7 +716,7 @@ public class CreateWriteTransactionTests
     }
 
     [Fact]
-    public async Task GetTransactionVersion_Returns_Latest_After_Multiple_Commits()
+    public async Task GetLatestTransactionVersion_Returns_Latest_After_Multiple_Commits()
     {
         var info = DirectoryHelpers.CreateTempSubdirectory();
         try
@@ -748,7 +748,7 @@ public class CreateWriteTransactionTests
                     CancellationToken.None);
             }
 
-            var txnVersion = await table.GetTransactionVersionAsync(
+            var txnVersion = await table.GetLatestTransactionVersionAsync(
                 "multi-version-app",
                 CancellationToken.None);
 

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -589,7 +589,7 @@ public class CreateWriteTransactionTests
     }
 
     [Fact]
-    public async Task CommitWriteTransaction_Duplicate_AppId_Version_Should_Fail_Or_Succeed()
+    public async Task CreateWriteTransaction_Duplicate_AppId_Version_Should_Fail_Or_Succeed()
     {
         var info = DirectoryHelpers.CreateTempSubdirectory();
         try
@@ -615,7 +615,7 @@ public class CreateWriteTransactionTests
                 },
             };
 
-            var version1 = await table.CommitWriteTransactionAsync(
+            var version1 = await table.CreateWriteTransactionAsync(
                 actions1,
                 options,
                 CancellationToken.None);
@@ -638,12 +638,121 @@ public class CreateWriteTransactionTests
             // The kernel commits it successfully — the latest txn version for
             // a given appId simply overwrites the previous one during action
             // reconciliation. No error is thrown.
-            var version2 = await table.CommitWriteTransactionAsync(
+            var version2 = await table.CreateWriteTransactionAsync(
                 actions2,
                 options,
                 CancellationToken.None);
 
             Assert.Equal(version1 + 1, version2);
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task GetTransactionVersion_Returns_Version_After_Commit()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var actions = new List<AddAction>
+            {
+                new AddAction
+                {
+                    Path = "part-00000.parquet",
+                    Size = 1024,
+                    ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    DataChange = true,
+                },
+            };
+
+            var options = new CommitOptions
+            {
+                AppId = "version-query-app",
+                TransactionVersion = 42,
+            };
+
+            await table.CreateWriteTransactionAsync(
+                actions,
+                options,
+                CancellationToken.None);
+
+            var txnVersion = await table.GetTransactionVersionAsync(
+                "version-query-app",
+                CancellationToken.None);
+
+            Assert.Equal(42, txnVersion);
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task GetTransactionVersion_Returns_Null_For_Unknown_AppId()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var txnVersion = await table.GetTransactionVersionAsync(
+                "nonexistent-app",
+                CancellationToken.None);
+
+            Assert.Null(txnVersion);
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task GetTransactionVersion_Returns_Latest_After_Multiple_Commits()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            for (int i = 1; i <= 3; i++)
+            {
+                var actions = new List<AddAction>
+                {
+                    new AddAction
+                    {
+                        Path = $"part-{i:D5}.parquet",
+                        Size = 1024 * i,
+                        ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    },
+                };
+
+                var options = new CommitOptions
+                {
+                    AppId = "multi-version-app",
+                    TransactionVersion = i * 100,
+                };
+
+                await table.CreateWriteTransactionAsync(
+                    actions,
+                    options,
+                    CancellationToken.None);
+            }
+
+            var txnVersion = await table.GetTransactionVersionAsync(
+                "multi-version-app",
+                CancellationToken.None);
+
+            Assert.Equal(300, txnVersion);
         }
         finally
         {

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -587,4 +587,67 @@ public class CreateWriteTransactionTests
             info.Delete(true);
         }
     }
+
+    [Fact]
+    public async Task CommitWriteTransaction_Duplicate_AppId_Version_Should_Fail_Or_Succeed()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var table = tableParts.table;
+
+            var options = new CommitOptions
+            {
+                AppId = "duplicate-test-app",
+                TransactionVersion = 100,
+            };
+
+            // First commit with appId/version should succeed
+            var actions1 = new List<AddAction>
+            {
+                new AddAction
+                {
+                    Path = "part-00000.parquet",
+                    Size = 1024,
+                    ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    DataChange = true,
+                },
+            };
+
+            var version1 = await table.CommitWriteTransactionAsync(
+                actions1,
+                options,
+                CancellationToken.None);
+
+            Assert.True(version1 > 0);
+
+            // Second commit with the SAME appId and version
+            var actions2 = new List<AddAction>
+            {
+                new AddAction
+                {
+                    Path = "part-00001.parquet",
+                    Size = 2048,
+                    ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    DataChange = true,
+                },
+            };
+
+            // The Delta Protocol does NOT prevent duplicate appId/version commits.
+            // The kernel commits it successfully — the latest txn version for
+            // a given appId simply overwrites the previous one during action
+            // reconciliation. No error is thrown.
+            var version2 = await table.CommitWriteTransactionAsync(
+                actions2,
+                options,
+                CancellationToken.None);
+
+            Assert.Equal(version1 + 1, version2);
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/delta-io/delta/blob/master/PROTOCOL.md#transaction-identifiers

1. Add support for blind append path for TransactionIdentifier (`appId`, `version`) pair.
     a. LastModified property is not included in this PR but can be upon request.
2. `GetLatestTransactionVersionAsync`(...) is also added. This scans the table for a given `appId` and gets the latest `version`. By "latest" it is defined to be as the `version` that appears last in the transacton log:
    a. Example: (log: 00000000000000000000.json - appId: 0, version: 100), (log: 00000000000000000001.json - appId: 0, version: 200), (log: 00000000000000000002.json - appId: 0, version: 150), `GetLatestTransactionVersionAsync("0")` returns 150

I am disallowing the case(s) where one of (`appId`, `version`) are not included but the other is. This is because both are required properties.
