### PR TITLE
Add NumRecords property to AddAction for stats passthrough

### DIFF
--- a/src/DeltaLake/Kernel/Arrow/Builders/AddActionRecordBatchBuilder.cs
+++ b/src/DeltaLake/Kernel/Arrow/Builders/AddActionRecordBatchBuilder.cs
@@ -76,7 +76,15 @@ namespace DeltaLake.Kernel.Arrow.Builders
                 pathBuilder.Append(action.Path);
                 sizeBuilder.Append(action.Size);
                 modTimeBuilder.Append(action.ModificationTime);
-                numRecordsBuilder.AppendNull();
+
+                if (action.NumRecords.HasValue)
+                {
+                    numRecordsBuilder.Append(action.NumRecords.Value);
+                }
+                else
+                {
+                    numRecordsBuilder.AppendNull();
+                }
 
                 mapBuilder.Append();
                 if (action.PartitionValues != null)

--- a/src/DeltaLake/Table/AddAction.cs
+++ b/src/DeltaLake/Table/AddAction.cs
@@ -50,6 +50,13 @@ namespace DeltaLake.Table
         public bool DataChange { get; init; } = true;
 
         /// <summary>
+        /// Number of records in the data file. Used for query planning and optimization.
+        /// When set, this value is written to the stats field in the delta log.
+        /// </summary>
+        [JsonPropertyName("numRecords")]
+        public long? NumRecords { get; init; }
+
+        /// <summary>
         /// Serializes this add action to a JSON string matching the Delta protocol format.
         /// </summary>
         /// <returns>A JSON string representation of this add action.</returns>

--- a/tests/DeltaLake.Tests/Table/AddActionRecordBatchBuilderTests.cs
+++ b/tests/DeltaLake.Tests/Table/AddActionRecordBatchBuilderTests.cs
@@ -312,4 +312,82 @@ public class AddActionRecordBatchBuilderTests
 
         Assert.Equal(2, batch.Length);
     }
+
+    [Fact]
+    public void Build_WithNumRecords_PopulatesStatsColumn()
+    {
+        var actions = new List<AddAction>
+        {
+            new AddAction
+            {
+                Path = "file1.parquet",
+                Size = 100,
+                ModificationTime = 1000,
+                NumRecords = 42,
+            },
+        };
+        using var batch = AddActionRecordBatchBuilder.Build(actions);
+        var statsArray = (StructArray)batch.Column("stats");
+        Assert.False(statsArray.IsNull(0));
+        var numRecords = (Int64Array)statsArray.Fields[0];
+        Assert.False(numRecords.IsNull(0));
+        Assert.Equal(42L, numRecords.GetValue(0));
+    }
+
+    [Fact]
+    public void Build_WithoutNumRecords_StatsStructIsNonNull_InnerFieldIsNull()
+    {
+        var actions = new List<AddAction>
+        {
+            new AddAction
+            {
+                Path = "file1.parquet",
+                Size = 100,
+                ModificationTime = 1000,
+            },
+        };
+        using var batch = AddActionRecordBatchBuilder.Build(actions);
+        var statsArray = (StructArray)batch.Column("stats");
+        Assert.False(statsArray.IsNull(0));
+        var numRecords = (Int64Array)statsArray.Fields[0];
+        Assert.True(numRecords.IsNull(0));
+    }
+
+    [Fact]
+    public void Build_MixedNumRecords_CorrectValues()
+    {
+        var actions = new List<AddAction>
+        {
+            new AddAction { Path = "a.parquet", Size = 1, ModificationTime = 1, NumRecords = 10 },
+            new AddAction { Path = "b.parquet", Size = 2, ModificationTime = 2 },
+            new AddAction { Path = "c.parquet", Size = 3, ModificationTime = 3, NumRecords = 30 },
+        };
+        using var batch = AddActionRecordBatchBuilder.Build(actions);
+        var statsArray = (StructArray)batch.Column("stats");
+
+        var numRecords = (Int64Array)statsArray.Fields[0];
+        Assert.Equal(10L, numRecords.GetValue(0));
+        Assert.True(numRecords.IsNull(1));
+        Assert.Equal(30L, numRecords.GetValue(2));
+    }
+
+    [Fact]
+    public void Build_NumRecordsZero_IsValid()
+    {
+        var actions = new List<AddAction>
+        {
+            new AddAction
+            {
+                Path = "empty.parquet",
+                Size = 50,
+                ModificationTime = 1000,
+                NumRecords = 0,
+            },
+        };
+        using var batch = AddActionRecordBatchBuilder.Build(actions);
+        var statsArray = (StructArray)batch.Column("stats");
+        Assert.False(statsArray.IsNull(0));
+        var numRecords = (Int64Array)statsArray.Fields[0];
+        Assert.Equal(0L, numRecords.GetValue(0));
+    }
 }

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -759,4 +759,96 @@ public class CreateWriteTransactionTests
             info.Delete(true);
         }
     }
+
+    [Fact]
+    public async Task CreateWriteTransaction_With_NumRecords_Writes_Stats_To_Log()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var (engine, table) = await TableHelpers.SetupTable(info.FullName, 1);
+            using (engine)
+            using (table)
+            {
+                var actions = new List<AddAction>
+                {
+                    new AddAction
+                    {
+                        Path = "part-00000.parquet",
+                        Size = 1234,
+                        ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        DataChange = true,
+                        NumRecords = 100,
+                    },
+                };
+
+                long version = await table.CreateWriteTransactionAsync(
+                    actions, CancellationToken.None);
+
+                string logFile = Path.Combine(info.FullName, "_delta_log",
+                    $"{version:D20}.json");
+                string[] lines = await File.ReadAllLinesAsync(logFile);
+
+                string? addLine = lines.FirstOrDefault(l => l.Contains("\"add\""));
+                Assert.NotNull(addLine);
+                // Kernel writes stats as JSON string: "stats":"{\"numRecords\":100}"
+                // The inner JSON may also appear as "numRecords":100 without escaping
+                Assert.True(
+                    addLine.Contains("\"numRecords\":100") || addLine.Contains("numRecords\\\":100"),
+                    $"Expected numRecords in log. Actual add line: {addLine}");
+            }
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
+    public async Task CreateWriteTransaction_Mixed_NumRecords_Only_Populated_Files_Have_Stats()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            var (engine, table) = await TableHelpers.SetupTable(info.FullName, 1);
+            using (engine)
+            using (table)
+            {
+                long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                var actions = new List<AddAction>
+                {
+                    new AddAction
+                    {
+                        Path = "with-stats.parquet",
+                        Size = 100,
+                        ModificationTime = now,
+                        NumRecords = 50,
+                    },
+                    new AddAction
+                    {
+                        Path = "no-stats.parquet",
+                        Size = 200,
+                        ModificationTime = now,
+                    },
+                };
+
+                long version = await table.CreateWriteTransactionAsync(
+                    actions, CancellationToken.None);
+
+                string logFile = Path.Combine(info.FullName, "_delta_log",
+                    $"{version:D20}.json");
+                string content = await File.ReadAllTextAsync(logFile);
+
+                Assert.True(
+                    content.Contains("\"numRecords\":50") || content.Contains("numRecords\\\":50"),
+                    $"Expected numRecords in log. Actual content: {content}");
+                Assert.Contains("with-stats.parquet", content);
+                Assert.Contains("no-stats.parquet", content);
+            }
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
 }


### PR DESCRIPTION
Changelog:
- Add long? NumRecords property to AddAction with JSON serialization
- Populate kernel stats struct numRecords column from AddAction.NumRecords
- When NumRecords is set, kernel writes {"numRecords":N} to delta log stats
- When NumRecords is null, behavior unchanged (empty stats object)

Follow-ups:
The kernel does not support setting stats beyond numRecords. To get this functionality we need to wait for updates to the kernel
1. NullCount
2. MinValues
3. MaxValues

Below are some items on delta-kernel-rs tracking additional stats functionality
| Link | Type | Title | Status |
|------|------|-------|--------|
| [delta-io/delta-kernel-rs#377](https://github.com/delta-io/delta-kernel-rs/issues/377) | Issue | [tracking] delta kernel write path | Open (4/5 sub-issues done) |
| [delta-io/delta-kernel-rs#788](https://github.com/delta-io/delta-kernel-rs/issues/788) | Issue | **write file statistics during appends** | **Open — THE blocker** |
| [delta-io/delta-kernel-rs#787](https://github.com/delta-io/delta-kernel-rs/pull/787) | PR | [WIP] write file statistics during appends | Draft (blocked on arrow-rs) |
| [delta-io/delta-kernel-rs#1748](https://github.com/delta-io/delta-kernel-rs/pull/1748) | PR | expand add files schema to include all stats fields | Merged |
| [delta-io/delta-kernel-rs#2442](https://github.com/delta-io/delta-kernel-rs/pull/2442) | PR | nullCount for array, map, variant columns | Open |
| [delta-io/delta-kernel-rs#2308](https://github.com/delta-io/delta-kernel-rs/pull/2308) | PR | graceful stats_parsed type mismatch degradation | Open |
| [delta-io/delta-kernel-rs#2249](https://github.com/delta-io/delta-kernel-rs/pull/2249) | PR | support max timestamp stats for data skipping | Merged |
| [delta-io/delta-kernel-rs#2088](https://github.com/delta-io/delta-kernel-rs/issues/2088) | Issue | Int64 → Timestamp widening for stats_parsed | Open |
| [delta-io/delta-kernel-rs#2049](https://github.com/delta-io/delta-kernel-rs/issues/2049) | Issue | scan_metadata stats_parsed for clustered tables | Open |
| [delta-io/delta-kernel-rs#1788](https://github.com/delta-io/delta-kernel-rs/issues/1788) | Issue | Support delta.dataSkippingStringPrefixLength | Open |
