### PR TITLE
Bump version to 0.32.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.31.1</Version>
+    <Version>0.32.0</Version>
     <!--
       .NET does not allow the above version format for AssemblyVersion, and this
       is the version used in gRPC headers. The format is
@@ -28,7 +28,7 @@
       and 0.2.0 then is 0.2.0.5. But if there is no prerelease version, just
       leave revision off.
     -->
-    <AssemblyVersion>0.31.1</AssemblyVersion>
+    <AssemblyVersion>0.32.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DeltaLake/DeltaLake.csproj
+++ b/src/DeltaLake/DeltaLake.csproj
@@ -11,7 +11,6 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Nullable>enable</Nullable>
         <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
-        <VersionSuffix>rc-1</VersionSuffix>
         <PackageTags>deltalake csharp</PackageTags>
         <PackageId>DeltaLake.Net</PackageId>
     </PropertyGroup>


### PR DESCRIPTION
Changelog so far (4/23/2026) between v0.31.1 and this new proposed v0.32.0

| Category | Change | PR |
|----------|--------|----|
| Feature | TransactionIdentifier support for blind appends (`CommitOptions.AppId`, `TransactionVersion`, `GetLatestTransactionVersionAsync`) | [#181](https://github.com/delta-incubator/delta-dotnet/pull/181) |
| Feature | Blind append support via delta-kernel-rs (`CreateWriteTransactionAsync`) | [#177](https://github.com/delta-incubator/delta-dotnet/pull/177) |
| Feature | Add NumRecords property to AddAction for stats passthrough | [#182](https://github.com/delta-incubator/delta-dotnet/pull/182)
| Feature | Upgrade delta-kernel-rs v0.14.0 to v0.17.0 | [#179](https://github.com/delta-incubator/delta-dotnet/pull/179) |
| Security | Enable Control Flow Guard (CFG) for Windows Rust binaries | [#180](https://github.com/delta-incubator/delta-dotnet/pull/180) |
| Maintenance | Reduce delta_rs_bridge size to 89MB | [#175](https://github.com/delta-incubator/delta-dotnet/pull/175) |
| Maintenance | Bump libc from 0.2.171 to 0.2.172 | [#142](https://github.com/delta-incubator/delta-dotnet/pull/142) |
| CI | Pin all GitHub Actions to full-length commit SHAs | [#178](https://github.com/delta-incubator/delta-dotnet/pull/178) |
| CI | Upgrade upload-pages-artifact v3 to v4 | [#178](https://github.com/delta-incubator/delta-dotnet/pull/178) |