### PR TITLE
feat(checkpoint): expose checkpoint format and sidecar options

### DIFF
--- a/src/DeltaLake/Interfaces/ITable.cs
+++ b/src/DeltaLake/Interfaces/ITable.cs
@@ -268,10 +268,9 @@ namespace DeltaLake.Interfaces
         Task CheckpointAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Create a checkpoint at the latest transaction using the supplied options, for example to
-        /// force a V2 checkpoint that writes file actions into sidecar files.
+        /// Create a checkpoint at the latest transaction using the supplied options.
         /// </summary>
-        /// <param name="options">Options controlling the checkpoint shape.</param>
+        /// <param name="options">Options controlling the checkpoint format.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
         /// <returns>A <see cref="Task"/>representing the checkpoint operation.</returns>
         Task CheckpointAsync(CheckpointOptions options, CancellationToken cancellationToken);

--- a/src/DeltaLake/Interfaces/ITable.cs
+++ b/src/DeltaLake/Interfaces/ITable.cs
@@ -268,6 +268,15 @@ namespace DeltaLake.Interfaces
         Task CheckpointAsync(CancellationToken cancellationToken);
 
         /// <summary>
+        /// Create a checkpoint at the latest transaction using the supplied options, for example to
+        /// force a V2 checkpoint that writes file actions into sidecar files.
+        /// </summary>
+        /// <param name="options">Options controlling the checkpoint shape.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
+        /// <returns>A <see cref="Task"/>representing the checkpoint operation.</returns>
+        Task CheckpointAsync(CheckpointOptions options, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Optimize an existing table
         /// </summary>
         /// <param name="options">Options for the operation</param>

--- a/src/DeltaLake/Kernel/Core/Table.cs
+++ b/src/DeltaLake/Kernel/Core/Table.cs
@@ -474,7 +474,7 @@ namespace DeltaLake.Kernel.Core
                         unsafe
                         {
                             ExternResultFfiCheckpointWriteResult result;
-                            if (options.Spec == CheckpointSpec.Auto)
+                            if (options.Format == CheckpointFormat.Auto)
                             {
                                 // Pass null to let the kernel auto-pick V1/V2.
                                 result = Methods.checkpoint_snapshot(
@@ -522,21 +522,21 @@ namespace DeltaLake.Kernel.Core
 
         /// <summary>
         /// Translates managed <see cref="CheckpointOptions"/> into the kernel FFI
-        /// <see cref="FfiCheckpointSpec"/>. Only called for non-<see cref="CheckpointSpec.Auto"/>
-        /// specs; the sidecar hint applies to <see cref="CheckpointSpec.V2WithSidecar"/> only.
+        /// <see cref="FfiCheckpointSpec"/>. Only called for non-<see cref="CheckpointFormat.Auto"/>
+        /// specs; the sidecar hint applies to <see cref="CheckpointFormat.V2WithSidecar"/> only.
         /// </summary>
         private static unsafe FfiCheckpointSpec BuildCheckpointSpec(CheckpointOptions options)
         {
             FfiCheckpointSpec spec = default;
-            switch (options.Spec)
+            switch (options.Format)
             {
-                case CheckpointSpec.V1:
+                case CheckpointFormat.V1:
                     spec.tag = FfiCheckpointSpec_Tag.FfiCheckpointSpecV1;
                     break;
-                case CheckpointSpec.V2NoSidecar:
+                case CheckpointFormat.V2NoSidecar:
                     spec.tag = FfiCheckpointSpec_Tag.FfiCheckpointSpecV2NoSidecar;
                     break;
-                case CheckpointSpec.V2WithSidecar:
+                case CheckpointFormat.V2WithSidecar:
                     spec.tag = FfiCheckpointSpec_Tag.FfiCheckpointSpecV2WithSidecar;
                     OptionalValueusize hint = default;
                     if (options.FileActionsPerSidecarHint is ulong hintValue)
@@ -553,8 +553,8 @@ namespace DeltaLake.Kernel.Core
                 default:
                     throw new ArgumentOutOfRangeException(
                         nameof(options),
-                        options.Spec,
-                        "Unsupported checkpoint spec.");
+                        options.Format,
+                        "Unsupported checkpoint Format.");
             }
 
             return spec;

--- a/src/DeltaLake/Kernel/Core/Table.cs
+++ b/src/DeltaLake/Kernel/Core/Table.cs
@@ -457,7 +457,7 @@ namespace DeltaLake.Kernel.Core
                 .ConfigureAwait(false);
         }
 
-        internal async Task CheckpointAsync(ICancellationToken cancellationToken)
+        internal async Task CheckpointAsync(CheckpointOptions options, ICancellationToken cancellationToken)
         {
             if (!this.isKernelAllocated)
             {
@@ -473,11 +473,23 @@ namespace DeltaLake.Kernel.Core
                     {
                         unsafe
                         {
-                            // Pass null to let the kernel auto-pick V1/V2.
-                            ExternResultFfiCheckpointWriteResult result = Methods.checkpoint_snapshot(
-                                this.state.Snapshot(refresh: true),
-                                this.kernelOwnedSharedExternEnginePtr,
-                                null);
+                            ExternResultFfiCheckpointWriteResult result;
+                            if (options.Spec == CheckpointSpec.Auto)
+                            {
+                                // Pass null to let the kernel auto-pick V1/V2.
+                                result = Methods.checkpoint_snapshot(
+                                    this.state.Snapshot(refresh: true),
+                                    this.kernelOwnedSharedExternEnginePtr,
+                                    null);
+                            }
+                            else
+                            {
+                                FfiCheckpointSpec spec = BuildCheckpointSpec(options);
+                                result = Methods.checkpoint_snapshot(
+                                    this.state.Snapshot(refresh: true),
+                                    this.kernelOwnedSharedExternEnginePtr,
+                                    &spec);
+                            }
 
                             if (result.tag != ExternResultFfiCheckpointWriteResult_Tag.OkFfiCheckpointWriteResult)
                             {
@@ -506,6 +518,46 @@ namespace DeltaLake.Kernel.Core
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Translates managed <see cref="CheckpointOptions"/> into the kernel FFI
+        /// <see cref="FfiCheckpointSpec"/>. Only called for non-<see cref="CheckpointSpec.Auto"/>
+        /// specs; the sidecar hint applies to <see cref="CheckpointSpec.V2WithSidecar"/> only.
+        /// </summary>
+        private static unsafe FfiCheckpointSpec BuildCheckpointSpec(CheckpointOptions options)
+        {
+            FfiCheckpointSpec spec = default;
+            switch (options.Spec)
+            {
+                case CheckpointSpec.V1:
+                    spec.tag = FfiCheckpointSpec_Tag.FfiCheckpointSpecV1;
+                    break;
+                case CheckpointSpec.V2NoSidecar:
+                    spec.tag = FfiCheckpointSpec_Tag.FfiCheckpointSpecV2NoSidecar;
+                    break;
+                case CheckpointSpec.V2WithSidecar:
+                    spec.tag = FfiCheckpointSpec_Tag.FfiCheckpointSpecV2WithSidecar;
+                    OptionalValueusize hint = default;
+                    if (options.FileActionsPerSidecarHint is ulong hintValue)
+                    {
+                        hint.tag = OptionalValueusize_Tag.Someusize;
+                        hint.Anonymous.Anonymous.some = hintValue;
+                    }
+                    else
+                    {
+                        hint.tag = OptionalValueusize_Tag.Noneusize;
+                    }
+                    spec.Anonymous.v2_with_sidecar.file_actions_per_sidecar_hint = hint;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(options),
+                        options.Spec,
+                        "Unsupported checkpoint spec.");
+            }
+
+            return spec;
         }
 
         #endregion Delta Kernel table operations

--- a/src/DeltaLake/Table/CheckpointOptions.cs
+++ b/src/DeltaLake/Table/CheckpointOptions.cs
@@ -1,0 +1,50 @@
+namespace DeltaLake.Table
+{
+    /// <summary>
+    /// Determines the shape of the checkpoint written by a checkpoint operation.
+    /// </summary>
+    public enum CheckpointSpec
+    {
+        /// <summary>
+        /// Let the kernel auto-pick a V1 or V2 checkpoint based on the table's protocol
+        /// features. This matches the default checkpoint behavior.
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Force a classic V1 checkpoint (a single checkpoint parquet file, no sidecars).
+        /// </summary>
+        V1,
+
+        /// <summary>
+        /// Force a V2 checkpoint whose file actions are written inline in the checkpoint
+        /// file (no sidecars). Requires a table that supports the <c>v2Checkpoint</c> feature.
+        /// </summary>
+        V2NoSidecar,
+
+        /// <summary>
+        /// Force a V2 checkpoint whose file actions are written into separate sidecar parquet
+        /// files under <c>_delta_log/_sidecars/</c>. Requires a table that supports the
+        /// <c>v2Checkpoint</c> feature.
+        /// </summary>
+        V2WithSidecar,
+    }
+
+    /// <summary>
+    /// Options controlling how a checkpoint is written.
+    /// </summary>
+    public record CheckpointOptions
+    {
+        /// <summary>
+        /// The checkpoint shape to write. Defaults to <see cref="CheckpointSpec.Auto"/>.
+        /// </summary>
+        public CheckpointSpec Spec { get; init; } = CheckpointSpec.Auto;
+
+        /// <summary>
+        /// Optional hint for the number of file actions to place in each sidecar file. Only used
+        /// when <see cref="Spec"/> is <see cref="CheckpointSpec.V2WithSidecar"/>; <see langword="null"/>
+        /// lets the kernel choose a default.
+        /// </summary>
+        public ulong? FileActionsPerSidecarHint { get; init; }
+    }
+}

--- a/src/DeltaLake/Table/CheckpointOptions.cs
+++ b/src/DeltaLake/Table/CheckpointOptions.cs
@@ -1,13 +1,13 @@
 namespace DeltaLake.Table
 {
     /// <summary>
-    /// Determines the shape of the checkpoint written by a checkpoint operation.
+    /// Determines the format of the checkpoint written by a checkpoint operation.
     /// </summary>
-    public enum CheckpointSpec
+    public enum CheckpointFormat
     {
         /// <summary>
         /// Let the kernel auto-pick a V1 or V2 checkpoint based on the table's protocol
-        /// features. This matches the default checkpoint behavior.
+        /// features.
         /// </summary>
         Auto,
 
@@ -36,13 +36,13 @@ namespace DeltaLake.Table
     public record CheckpointOptions
     {
         /// <summary>
-        /// The checkpoint shape to write. Defaults to <see cref="CheckpointSpec.Auto"/>.
+        /// The checkpoint format to write. Defaults to <see cref="CheckpointFormat.Auto"/>.
         /// </summary>
-        public CheckpointSpec Spec { get; init; } = CheckpointSpec.Auto;
+        public CheckpointFormat Format { get; init; } = CheckpointFormat.Auto;
 
         /// <summary>
-        /// Optional hint for the number of file actions to place in each sidecar file. Only used
-        /// when <see cref="Spec"/> is <see cref="CheckpointSpec.V2WithSidecar"/>; <see langword="null"/>
+        /// Optional hint for the number of file actions to place in each sidecar file. Should be used only
+        /// when <see cref="Format"/> is <see cref="CheckpointFormat.V2WithSidecar"/>; <see langword="null"/>
         /// lets the kernel choose a default.
         /// </summary>
         public ulong? FileActionsPerSidecarHint { get; init; }

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -236,7 +236,13 @@ namespace DeltaLake.Table
         /// <inheritdoc/>
         public async Task CheckpointAsync(CancellationToken cancellationToken)
         {
-            await table.CheckpointAsync(cancellationToken).ConfigureAwait(false);
+            await table.CheckpointAsync(new CheckpointOptions(), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task CheckpointAsync(CheckpointOptions options, CancellationToken cancellationToken)
+        {
+            await table.CheckpointAsync(options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -234,15 +234,13 @@ namespace DeltaLake.Table
         ) => this.AddConstraintsAsync(constraints, null, cancellationToken);
 
         /// <inheritdoc/>
-        public async Task CheckpointAsync(CancellationToken cancellationToken)
-        {
-            await table.CheckpointAsync(new CheckpointOptions(), cancellationToken).ConfigureAwait(false);
-        }
+        public Task CheckpointAsync(CancellationToken cancellationToken)
+            => CheckpointAsync(new CheckpointOptions(), cancellationToken);
 
         /// <inheritdoc/>
         public async Task CheckpointAsync(CheckpointOptions options, CancellationToken cancellationToken)
         {
-            await table.CheckpointAsync(options, cancellationToken).ConfigureAwait(false);
+            await this.table.CheckpointAsync(options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/tests/DeltaLake.Tests/Table/CheckpointTests.cs
+++ b/tests/DeltaLake.Tests/Table/CheckpointTests.cs
@@ -372,7 +372,7 @@ namespace DeltaLake.Tests.Table
                 var data = await TableHelpers.SetupTable(path, 1);
                 using var table = data.table;
 
-                // The parameterless default (CheckpointSpec.Auto) matches the pre-options behavior.
+                // The parameterless default (CheckpointFormat.Auto) matches the pre-options behavior.
                 await table.CheckpointAsync(new CheckpointOptions(), CancellationToken.None);
 
                 var lastCheckpoint = Path.Join(info.FullName, "_delta_log", "_last_checkpoint");
@@ -395,7 +395,7 @@ namespace DeltaLake.Tests.Table
                 using var table = data.table;
 
                 await table.CheckpointAsync(
-                    new CheckpointOptions { Spec = CheckpointSpec.V1 },
+                    new CheckpointOptions { Format = CheckpointFormat.V1 },
                     CancellationToken.None);
 
                 var lastCheckpoint = Path.Join(info.FullName, "_delta_log", "_last_checkpoint");
@@ -424,7 +424,7 @@ namespace DeltaLake.Tests.Table
                     async () => await table.CheckpointAsync(
                         new CheckpointOptions
                         {
-                            Spec = CheckpointSpec.V2WithSidecar,
+                            Format = CheckpointFormat.V2WithSidecar,
                             FileActionsPerSidecarHint = 1,
                         },
                         CancellationToken.None));

--- a/tests/DeltaLake.Tests/Table/CheckpointTests.cs
+++ b/tests/DeltaLake.Tests/Table/CheckpointTests.cs
@@ -1,4 +1,5 @@
 using DeltaLake.Interfaces;
+using DeltaLake.Kernel.Callbacks.Errors;
 using DeltaLake.Table;
 
 namespace DeltaLake.Tests.Table
@@ -359,6 +360,80 @@ namespace DeltaLake.Tests.Table
             Assert.Equal(length + 2, history.Length);
             await table.CheckpointAsync(CancellationToken.None);
             await more(table);
+        }
+
+        [Fact]
+        public async Task File_System_Checkpoint_With_Auto_Options_Writes_Checkpoint()
+        {
+            var info = DirectoryHelpers.CreateTempSubdirectory();
+            try
+            {
+                var path = DirectoryHelpers.ToFileUri(info.FullName);
+                var data = await TableHelpers.SetupTable(path, 1);
+                using var table = data.table;
+
+                // The parameterless default (CheckpointSpec.Auto) matches the pre-options behavior.
+                await table.CheckpointAsync(new CheckpointOptions(), CancellationToken.None);
+
+                var lastCheckpoint = Path.Join(info.FullName, "_delta_log", "_last_checkpoint");
+                Assert.True(File.Exists(lastCheckpoint));
+            }
+            finally
+            {
+                info.Delete(true);
+            }
+        }
+
+        [Fact]
+        public async Task File_System_Checkpoint_With_V1_Spec_Writes_Checkpoint()
+        {
+            var info = DirectoryHelpers.CreateTempSubdirectory();
+            try
+            {
+                var path = DirectoryHelpers.ToFileUri(info.FullName);
+                var data = await TableHelpers.SetupTable(path, 1);
+                using var table = data.table;
+
+                await table.CheckpointAsync(
+                    new CheckpointOptions { Spec = CheckpointSpec.V1 },
+                    CancellationToken.None);
+
+                var lastCheckpoint = Path.Join(info.FullName, "_delta_log", "_last_checkpoint");
+                Assert.True(File.Exists(lastCheckpoint));
+            }
+            finally
+            {
+                info.Delete(true);
+            }
+        }
+
+        [Fact]
+        public async Task File_System_Checkpoint_V2_Sidecar_Spec_Reaches_Kernel_And_Requires_Feature()
+        {
+            var info = DirectoryHelpers.CreateTempSubdirectory();
+            try
+            {
+                var path = DirectoryHelpers.ToFileUri(info.FullName);
+                var data = await TableHelpers.SetupTable(path, 1);
+                using var table = data.table;
+
+                // The table does not enable the v2Checkpoint feature, so forcing a V2 checkpoint
+                // with sidecars surfaces the kernel's CheckpointWriteError. This confirms the sidecar
+                // spec is marshalled and passed through to the kernel rather than silently ignored.
+                var ex = await Assert.ThrowsAsync<KernelException>(
+                    async () => await table.CheckpointAsync(
+                        new CheckpointOptions
+                        {
+                            Spec = CheckpointSpec.V2WithSidecar,
+                            FileActionsPerSidecarHint = 1,
+                        },
+                        CancellationToken.None));
+                Assert.Contains("v2Checkpoint", ex.Message);
+            }
+            finally
+            {
+                info.Delete(true);
+            }
         }
     }
 }


### PR DESCRIPTION
Exposes control over the checkpoint **format** when writing a checkpoint. Adds a public `CheckpointOptions` record with a `CheckpointFormat` enum (`Auto`, `V1`, `V2NoSidecar`, `V2WithSidecar`) and an optional `FileActionsPerSidecarHint`, plus a `CheckpointAsync(CheckpointOptions, CancellationToken)` overload on `ITable` / `DeltaTable`. The managed options are translated into the kernel's `FfiCheckpointSpec` and passed through the v0.26 `checkpoint_snapshot(snapshot, engine, spec)` FFI, so callers can force a classic V1 checkpoint or a V2 checkpoint with inline or sidecar file actions. The parameterless `CheckpointAsync` keeps its current behavior via `CheckpointFormat.Auto` (the kernel auto-picks V1/V2).