### PR TITLE
chore: bump version to 0.33.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.32.0</Version>
+    <Version>0.33.0</Version>
     <!--
       .NET does not allow the above version format for AssemblyVersion, and this
       is the version used in gRPC headers. The format is
@@ -28,7 +28,7 @@
       and 0.2.0 then is 0.2.0.5. But if there is no prerelease version, just
       leave revision off.
     -->
-    <AssemblyVersion>0.32.0</AssemblyVersion>
+    <AssemblyVersion>0.33.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bumps the `DeltaLake.Net` package version from `0.32.0` to `0.33.0` for the release covering the recently merged delta-kernel-rs v0.26 upgrade (#210) and the checkpoint format / sidecar options (#211).

## How was this change tested?

Version metadata only (`Directory.Build.props`); no functional change. The solution builds across `net472` / `net8.0` / `net9.0`.
