### PR TITLE
fix: avoid redundant latest-version lookup

### DIFF
--- a/src/DeltaLake/Bridge/src/table.rs
+++ b/src/DeltaLake/Bridge/src/table.rs
@@ -646,11 +646,12 @@ async fn table_update_incremental_impl(
     table: &mut deltalake::DeltaTable,
     max_version: Option<u64>,
 ) -> Result<(), deltalake::DeltaTableError> {
-    let latest_version = table.get_latest_version().await?;
-    let max_version = if let Some(max_version) = max_version {
-        Some(std::cmp::min(max_version, latest_version))
-    } else {
-        None
+    let max_version = match max_version {
+        Some(max_version) => {
+            let latest_version = table.get_latest_version().await?;
+            Some(std::cmp::min(max_version, latest_version))
+        }
+        None => None,
     };
 
     table.update_incremental(max_version).await

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -41,6 +41,53 @@ public class CreateWriteTransactionTests
     }
 
     [Fact]
+    public async Task CreateWriteTransaction_Then_UpdateIncremental_Null_Advances_Bridge()
+    {
+        var info = DirectoryHelpers.CreateTempSubdirectory();
+        try
+        {
+            using var schemaBatch = TableHelpers.BuildBasicRecordBatch(0);
+            using var engine = new DeltaEngine(EngineOptions.Default);
+            using var table = await engine.CreateTableAsync(
+                new TableCreateOptions(info.FullName, schemaBatch.Schema),
+                CancellationToken.None);
+
+            var initialVersion = Assert.IsType<ulong>(table.Version());
+            var logDirectory = Path.Combine(info.FullName, "_delta_log");
+            var checkpointPath = Path.Combine(
+                logDirectory,
+                $"{initialVersion:D20}.checkpoint.parquet");
+            var jsonPath = Path.Combine(logDirectory, $"{initialVersion:D20}.json");
+
+            await table.CheckpointAsync(CancellationToken.None);
+            Assert.True(File.Exists(checkpointPath));
+
+            // The checkpoint keeps the table valid, while removing this JSON commit
+            // forces an unbounded incremental update to resume from the checkpoint.
+            File.Delete(jsonPath);
+
+            const string committedPath = "k.parquet";
+            var committedVersion = await table.CreateWriteTransactionAsync(
+                [new AddAction
+                {
+                    Path = committedPath,
+                    Size = 1024,
+                    ModificationTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    DataChange = true,
+                }],
+                CancellationToken.None);
+
+            await table.UpdateIncrementalAsync(null, CancellationToken.None);
+
+            Assert.Equal((ulong)committedVersion, table.Version());
+        }
+        finally
+        {
+            info.Delete(true);
+        }
+    }
+
+    [Fact]
     public async Task CreateWriteTransaction_Multiple_Commits_Increment_Version()
     {
         var info = DirectoryHelpers.CreateTempSubdirectory();


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change skips `DeltaTable::get_latest_version()` when `UpdateIncrementalAsync` is called without a maximum version. The unbounded path passes `None` directly to delta-rs so it can advance from the loaded state without a redundant latest-version lookup.

A regression test now creates a checkpoint-backed table, writes a commit through the kernel transaction path, and verifies that `UpdateIncrementalAsync(null, ...)` completes and advances to the committed version.

The bounded path still resolves the latest version before clamping `maxVersion`; this change intentionally leaves that existing behavior unchanged.

## How was this change tested?

- `dotnet build DeltaLake.sln -c Release`
- `dotnet format DeltaLake.sln --verify-no-changes --no-restore`
- `dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov.info --logger "console;verbosity=detailed" --blame-crash --blame-hang --blame-hang-timeout 5m -v n`

All 266 tests passed with coverage enabled.
